### PR TITLE
chore: split builds, add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jamieastley

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,4 +24,7 @@ export default defineConfig({
       manifest: generateManifest,
     }),
   ],
+  build: {
+    outDir: "dist/" + target,
+  },
 });


### PR DESCRIPTION
Splits out production builds to browser-specific directories under `dist`

- adds `CODEOWNERS`