### PR TITLE
fix: output directory for dist builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "dev:firefox": "TARGET=firefox vite dev",
     "dev:chrome": "TARGET=chrome vite dev",
-    "build:chrome": "tsc && vite build",
+    "build:chrome": "tsc && TARGET=chrome vite build",
     "build:firefox": "tsc -b && TARGET=firefox vite build",
     "prettier": "prettier --write .",
     "prettier:check": "prettier --check .",

--- a/vite.config.js
+++ b/vite.config.js
@@ -27,4 +27,7 @@ export default defineConfig({
             manifest: generateManifest,
         }),
     ],
+    build: {
+        outDir: "dist/" + target,
+    },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,8 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import webExtension, { readJsonFile } from "vite-plugin-web-extension";
 
-const target = process.env.TARGET || "chrome";
+const target =
+  process.env.TARGET && process.env.TARGET.trim() !== "" ? process.env.TARGET : "chrome";
 
 function generateManifest() {
   const manifest = readJsonFile("src/manifest.json");


### PR DESCRIPTION
- adds missing `TARGET` env var and handle empty strings